### PR TITLE
A more generic script

### DIFF
--- a/docker/osl.Dockerfile
+++ b/docker/osl.Dockerfile
@@ -1,0 +1,33 @@
+ARG BUILDER_IMAGE
+ARG RUNTIME_IMAGE
+
+FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0-6} AS builder
+
+ARG QUARKUS_EXTENSIONS
+ENV QUARKUS_EXTENSIONS=${QUARKUS_EXTENSIONS}
+
+ARG MAVEN_ARGS_APPEND
+ENV MAVEN_ARGS_APPEND=${MAVEN_ARGS_APPEND}
+
+COPY --chown=1001 . .
+
+RUN /home/kogito/launch/build-app.sh
+
+#=============================
+# Runtime
+#=============================
+FROM ${RUNTIME_IMAGE:-registry.access.redhat.com/ubi9/openjdk-17:1.21-2}
+
+ENV LANGUAGE='en_US:en' LANG='en_US.UTF-8' 
+
+COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/lib/ /deployments/lib/
+COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/*.jar /deployments/
+COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/app/ /deployments/app/
+COPY --from=builder --chown=185 /home/kogito/serverless-workflow-project/target/quarkus-app/quarkus/ /deployments/quarkus/
+
+EXPOSE 8080
+USER 185
+ENV JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
+
+ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/docker/osl.Dockerfile.dockerignore
+++ b/docker/osl.Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+*
+!LICENSE
+!pom.xml
+!src/main/java/**/*
+!src/main/resources/**/*

--- a/docker/osl.Dockerfile.dockerignore
+++ b/docker/osl.Dockerfile.dockerignore
@@ -1,5 +1,4 @@
 *
 !LICENSE
-!pom.xml
 !src/main/java/**/*
 !src/main/resources/**/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_name="${BASH_SOURCE:-$0}"
+script_path=$(realpath "$script_name")
+scripts_dir_path=$(dirname "$script_path")
+
+# shellcheck disable=SC1091
+source "${scripts_dir_path}/lib/_functions.sh"
+# shellcheck disable=SC1091
+source "${scripts_dir_path}/lib/_logger.sh"
+
+function usage {
+    cat <<EOF
+This script performs the following tasks in this specific order:
+1. Generates a list of Operator manifests for a SonataFlow project
+2. Builds the workflow image using 
+3. Optionally deploys.
+    3.1 Pushes the image to a registry (specidied in the image path)
+    3.2 Applies the generated manifests in the current k8s namespace
+
+Usage: 
+    $script_name [flags]
+
+Flags:
+    -i|--image string                 The image path to use for the workflow (required).
+    -b|--builder-image string         Overrides the image to use for building the workflow image.
+    -h|--help                         Prints this help message.
+    -r|--runtime-image string         Overrides the image to use for running the workflow.
+    -w|--workflow-directory string    Path to the directory containing the workflow's files (the 'src' directory). Default: current directory.
+    -P|--no-persistence               Skips adding persistence configuration to the sonataflow CR.
+       --apply                        Applies the generated manifests in the current namespace.
+       --push                         Pushes the image to the registry after building
+
+Notes: 
+    1. The manifests will be in 'manifests' beside 'src'.
+    2. This script respects the 'QUARKUS_EXTENSIONS' and 'MAVEN_ARGS_APPEND' environment variables.
+EOF
+}
+
+declare -A args
+args["apply"]=""
+args["image"]=""
+args["no-persistence"]=""
+args["push"]=""
+args["workflow-directory"]="$PWD"
+args["builder-image"]=""
+args["runtime-image"]=""
+
+function parse_args {
+    while getopts ":i:b:r:w:hP-:" opt; do
+        case $opt in
+            h) usage; exit ;;
+            P) args["no-persistence"]="YES" ;;
+            i) args["image"]="$OPTARG" ;;
+            w) args["workflow-directory"]="$OPTARG" ;;
+            b) args["builder-image"]="$OPTARG" ;;
+            r) args["runtime-image"]="$OPTARG" ;;
+            -)
+                case "${OPTARG}" in
+                    help)
+                        usage; exit ;;
+                    apply)
+                        args["apply"]="YES" ;;
+                    no-persistence)
+                        args["no-persistence"]="YES" ;;
+                    push)
+                        args["push"]="YES" ;;
+                    image=*)
+                        args["image"]="${OPTARG#*=}" ;;
+                    workflow-directory=*)
+                        args["workflow-directory"]="${OPTARG#*=}" ;;
+                    builder-image=*)
+                        args["builder-image"]="${OPTARG#*=}" ;;
+                    runtime-image=*)
+                        args["runtime-image"]="${OPTARG#*=}" ;;
+                    *) log_error "Invalid option: --$OPTARG"; usage; exit 1 ;;
+                esac
+            ;;
+            \?) log_error "Invalid option: -$OPTARG"; usage; exit 2 ;;
+            :) log_error "Option -$OPTARG requires an argument."; usage; exit 3 ;;
+        esac
+    done
+
+    if [[ -z "${args["image"]:-}" ]]; then
+        log_error "Missing required flag: --image"
+        usage; exit 4
+    fi
+}
+
+function gen_manifests {
+    local res_dir_path="${args["workflow-directory"]}/src/main/resources"
+    local workflow_id
+
+    workflow_id=$(get_workflow_id "$res_dir_path")
+
+    cd "$res_dir_path"
+    log_info "Switched directory: $res_dir_path"
+
+    kn-workflow gen-manifest \
+        -c "${args["workflow-directory"]}/manifests" \
+        --profile 'gitops' \
+        --skip-namespace \
+        --image "${args["image"]}"
+
+    cd "${args["workflow-directory"]}"
+    log_info "Switched directory: ${args["workflow-directory"]}"
+
+    # Find the sonataflow CR for the workflow
+    sonataflow_cr=$(findw manifests -type f -name "*-sonataflow_${workflow_id}.yaml")
+
+    if [[ -f secret.properties ]]; then
+        yq --inplace ".spec.podTemplate.container.envFrom=[{\"secretRef\": { \"name\": \"${workflow_id}-creds\"}}]" "${sonataflow_cr}"
+        kubectl create secret generic "${workflow_id}-creds" \
+            --from-env-file=secret.properties \
+            --dry-run=client -o=yaml > "manifests/00-secret_${workflow_id}.yaml"
+        log_info "Generated k8s secret for the workflow"
+    fi
+
+    if [[ -z "${args["no-persistence"]:-}" ]]; then
+        yq --inplace ".spec |= (
+            . + {
+                \"persistence\": {
+                    \"postgresql\": {
+                        \"secretRef\": {
+                            \"name\": \"sonataflow-psql-postgresql\",
+                            \"userKey\": \"postgres-username\",
+                            \"passwordKey\": \"postgres-password\"
+                        },
+                        \"serviceRef\": {
+                            \"name\": \"sonataflow-psql-postgresql\",
+                            \"port\": 5432,
+                            \"databaseName\": \"sonataflow\",
+                            \"databaseSchema\": \"${workflow_id}\"
+                        }
+                    }
+                }
+            }
+        )" "${sonataflow_cr}"
+        log_info "Added persistence configuration to the sonataflow CR"
+    fi
+}
+
+function build_image {
+    local image_name="${args["image"]%:*}"
+    local tag="${args["image"]#*:}"
+
+    # These add-ons enable the use of JDBC for persisting workflow states and correlation
+    # contexts in serverless workflow applications.
+    base_quarkus_extensions="\
+    org.kie:kie-addons-quarkus-persistence-jdbc:9.102.0.redhat-00005,\
+    io.quarkus:quarkus-jdbc-postgresql:3.8.6.redhat-00004,\
+    io.quarkus:quarkus-agroal:3.8.6.redhat-00004"
+
+    # The 'maxYamlCodePoints' parameter contols the maximum size for YAML input files. 
+    # Set to 35000000 characters which is ~33MB in UTF-8.  
+    base_maven_args_append="\
+    -DmaxYamlCodePoints=35000000 \
+    -Dkogito.persistence.type=jdbc \
+    -Dquarkus.datasource.db-kind=postgresql \
+    -Dkogito.persistence.proto.marshaller=false"
+    
+    if [[ -n "${QUARKUS_EXTENSIONS:-}" ]]; then
+        base_quarkus_extensions="${base_quarkus_extensions},${QUARKUS_EXTENSIONS}"
+    fi
+
+    if [[ -n "${MAVEN_ARGS_APPEND:-}" ]]; then
+        base_maven_args_append="${base_maven_args_append} ${MAVEN_ARGS_APPEND}"
+    fi
+
+    # Build specifically for linux/amd64 to ensure compatibility with OSL v1.35.0
+    pocker_args=(
+        -f="${args["workflow-directory"]}/docker/osl.Dockerfile"
+        --platform='linux/amd64'
+        --ulimit='nofile=4096:4096'
+        --build-arg="QUARKUS_EXTENSIONS=${base_quarkus_extensions}"
+        --build-arg="MAVEN_ARGS_APPEND=${base_maven_args_append}"
+    )
+    [[ -n "${args["builder-image"]:-}" ]] && pocker_args+=(--build-arg="BUILDER_IMAGE=${args["builder-image"]}")
+    [[ -n "${args["runtime-image"]:-}" ]] && pocker_args+=(--build-arg="RUNTIME_IMAGE=${args["runtime-image"]}")
+
+    log_info "Building the workflow image"
+    pocker build "${pocker_args[@]}" "${args["workflow-directory"]}"
+    pocker tag "${args["image"]}" "$image_name:$(git rev-parse --short=8 HEAD)"
+    if [[ "$tag" != "latest" ]]; then
+        pocker tag "${args["image"]}" "$image_name:latest"
+    fi
+    pocker images --filter="reference=$image_name" --format="{{.Repository}}:{{.Tag}}"
+}
+
+function maybe_deploy {
+    local image_name="${args["image"]%:*}"
+    local tag="${args["image"]#*:}"
+
+    if [[ -n "${args["push"]}" ]]; then
+        docker push "${args["image"]}"
+        docker push "$image_name:$(git rev-parse --short=8 HEAD)"
+        if [[ "$tag" != "latest" ]]; then
+            docker push "$image_name:latest"
+        fi
+    fi
+
+    if [[ -n "${args["apply"]}" ]]; then
+        kubectl apply -f "${args["workflow-directory"]}/manifests"
+        log_info "Applied the generated manifests"
+    fi
+}
+
+parse_args "$@"
+
+gen_manifests
+build_image
+maybe_deploy

--- a/scripts/lib/_functions.sh
+++ b/scripts/lib/_functions.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+function is_macos {
+    [[ "$(uname)" == "Darwin" ]]
+}
+
+# A wrapper for the find command that uses the -E flag on macOS.
+# Extended regex (ERE) is not supported by default on macOS.
+function findw {
+    if is_macos; then
+        find -E "$@"
+    else
+        find "$@"
+    fi
+}
+
+function get_workflow_id {
+    local workdir=${1:-$PWD}
+    local workflow_file=""
+    local workflow_id=""
+
+    workflow_file=$(findw "$workdir" -type f -regex '.*\.sw\.ya?ml$')
+    if [ -z "$workflow_file" ]; then
+        echo "ERROR: No workflow file found with *.sw.yaml or *.sw.yml suffix"
+        return 10
+    fi
+
+    workflow_id=$(yq '.id | downcase' "$workflow_file" 2>/dev/null)
+    if [ -z "$workflow_id" ]; then
+        echo "ERROR: The workflow file doesn't seem to have an 'id' property."
+        return 11
+    fi
+
+    echo "$workflow_id"
+}
+
+function pocker {
+    $(command -v podman || command -v docker) "$@"
+}

--- a/scripts/lib/_functions.sh
+++ b/scripts/lib/_functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function is_macos {
-    [[ "$(uname)" == "Darwin" ]]
+    [[ "$(uname)" == Darwin ]]
 }
 
 # A wrapper for the find command that uses the -E flag on macOS.
@@ -15,19 +15,19 @@ function findw {
 }
 
 function get_workflow_id {
-    local workdir=${1:-$PWD}
+    local workdir="$1"
     local workflow_file=""
     local workflow_id=""
 
     workflow_file=$(findw "$workdir" -type f -regex '.*\.sw\.ya?ml$')
     if [ -z "$workflow_file" ]; then
-        echo "ERROR: No workflow file found with *.sw.yaml or *.sw.yml suffix"
+        log_error "No workflow file found with *.sw.yaml or *.sw.yml suffix"
         return 10
     fi
 
     workflow_id=$(yq '.id | downcase' "$workflow_file" 2>/dev/null)
     if [ -z "$workflow_id" ]; then
-        echo "ERROR: The workflow file doesn't seem to have an 'id' property."
+        log_error "The workflow file doesn't seem to have an 'id' property."
         return 11
     fi
 
@@ -36,4 +36,13 @@ function get_workflow_id {
 
 function pocker {
     $(command -v podman || command -v docker) "$@"
+}
+
+function assert_optarg_not_empty {
+    local arg="$1"
+
+    if [[ -z "${arg#*=}" ]]; then
+        log_error "Option --${arg%=*} requires an argument when specified."
+        return 12
+    fi
 }

--- a/scripts/lib/_logger.sh
+++ b/scripts/lib/_logger.sh
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
 
-set -eu
-
 RED='\033[0;31m'
 YELLOW='\033[0;33m'
 DEFAULT='\033[0m'
 
 function log_warning() {
-  local message="${1}"
+  local message="$1"
 
   echo >&2 -e "${YELLOW}WARN: ${message}${DEFAULT}"
 }
 
 function log_error() {
-  local message="${1}"
+  local message="$1"
 
   echo >&2 -e "${RED}ERROR: ${message}${DEFAULT}"
 }
 
 function log_info() {
-  local message="${1}"
+  local message="$1"
 
   echo >&2 -e "INFO: ${message}"
 }

--- a/scripts/lib/_logger.sh
+++ b/scripts/lib/_logger.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu
+
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+DEFAULT='\033[0m'
+
+function log_warning() {
+  local message="${1}"
+
+  echo >&2 -e "${YELLOW}WARN: ${message}${DEFAULT}"
+}
+
+function log_error() {
+  local message="${1}"
+
+  echo >&2 -e "${RED}ERROR: ${message}${DEFAULT}"
+}
+
+function log_info() {
+  local message="${1}"
+
+  echo >&2 -e "INFO: ${message}"
+}


### PR DESCRIPTION
Adds a more generic build script allowing the following use cases:

- The workflow directory can be specified using a flag
- Optionally --apply the manifests or --push the image to a registry (Useful in CI/CD envs)
- Respects QUARKUS_EXTENSION and MAVEN_ARGS_APPEND env variables
- Generates manifests leveraging kn-workflow and builds the workflow image using the OSL 1.35.0 builder image
- The builder and runtime image layers can be tweaked using the --builder-image and --runtime-image flags
- The persistence manifest is generated by default, use --no-persistance to opt-out.

Disclaimer:
1. I haven't tested this PR in this repo yet, but I have been using the scripts to build my own workflow (https://github.com/jkilzi/optimizer-swf.git)
2. The workflow is expected to have been created by kn-workflow v1.35.0 (RH build) using `kn workflow quarkus create`
3. The pom.xml is transfered to the builder image layer, so double check the dependencies! Refer to my version of the pom.xml as a baseline, it contains sane defaults (or at least I hope so)

Hope you find it useful 😉.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
