### PR TITLE
Use builder image based on 1.36 builder image

### DIFF
--- a/docker/osl.Dockerfile
+++ b/docker/osl.Dockerfile
@@ -1,7 +1,8 @@
 ARG BUILDER_IMAGE
 ARG RUNTIME_IMAGE
 
-FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0-6} AS builder
+FROM ${BUILDER_IMAGE:-registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0-8} AS builder
+#FROM ${BUILDER_IMAGE:-quay.io/orchestrator/logic-swf-builder-rhel8:1.36.0-disconnected} AS builder
 
 # Variables that can be overridden by the builder
 # To add a Quarkus extension to your application
@@ -13,9 +14,9 @@ ARG MAVEN_ARGS_APPEND
 ENV MAVEN_ARGS_APPEND=${MAVEN_ARGS_APPEND}
 
 # Create the Quarkus config directory and add the config.yaml file
-RUN mkdir -p /home/kogito/.quarkus && \
-    printf "registries:\n  - registry.quarkus.redhat.com\n" > $HOME/.quarkus/config.yaml && \
-    chown -R 1001:0 /home/kogito/.quarkus
+# RUN mkdir -p /home/kogito/.quarkus && \
+#     printf "registries:\n  - registry.quarkus.redhat.com\n" > $HOME/.quarkus/config.yaml && \
+#     chown -R 1001:0 /home/kogito/.quarkus
 
 COPY --chown=1001 . .
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -184,9 +184,12 @@ function build_image {
     # These add-ons enable the use of JDBC for persisting workflow states and correlation
     # contexts in serverless workflow applications.
     local base_quarkus_extensions="\
-    org.kie:kie-addons-quarkus-persistence-jdbc:9.102.0.redhat-00005,\
-    io.quarkus:quarkus-jdbc-postgresql:3.8.6.redhat-00004,\
-    io.quarkus:quarkus-agroal:3.8.6.redhat-00004"
+    io.quarkiverse.openapi.generator:quarkus-openapi-generator:2.9.1-lts,\
+    org.kie:kie-addons-quarkus-monitoring-sonataflow,\
+    org.kie:kogito-addons-quarkus-jobs-knative-eventing,\
+    org.kie:kie-addons-quarkus-persistence-jdbc,\
+    io.quarkus:quarkus-jdbc-postgresql:3.15.4.redhat-00001,\
+    io.quarkus:quarkus-agroal:3.15.4.redhat-00001"
 
     # The 'maxYamlCodePoints' parameter contols the maximum size for YAML input files. 
     # Set to 35000000 characters which is ~33MB in UTF-8.  

--- a/swf-image-builder/Dockerfile
+++ b/swf-image-builder/Dockerfile
@@ -1,19 +1,19 @@
-FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.35.0-6
+FROM registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel8:1.36.0-8
 
 ENV QUARKUS_PLATFORM_GROUPID=com.redhat.quarkus.platform
-ENV QUARKUS_PLATFORM_VERSION=3.8.6.SP2-redhat-00002
+ENV QUARKUS_PLATFORM_VERSION=3.15.4.redhat-00001
 
 # Additional Java/Maven arguments to pass to the builder
 ARG MAVEN_ARGS_APPEND
 ENV MAVEN_ARGS_APPEND=${MAVEN_ARGS_APPEND}
 
 # Create the .quarkus directory and set correct ownership
-RUN mkdir -p /home/kogito/.quarkus
+# RUN mkdir -p /home/kogito/.quarkus
 
 # Copy config.yaml to the .quarkus directory
-COPY --chown=1001 ./config.yaml /home/kogito/.quarkus/config.yaml
+# COPY --chown=1001 ./config.yaml /home/kogito/.quarkus/config.yaml
 
-RUN chown -R 1001:0 /home/kogito/.quarkus
+# RUN chown -R 1001:0 /home/kogito/.quarkus
 
 COPY --chown=1001 ./pom.xml /home/kogito/serverless-workflow-project/pom.xml
 #RUN chown 1001:0 /home/kogito/serverless-workflow-project/pom.xml

--- a/swf-image-builder/README.md
+++ b/swf-image-builder/README.md
@@ -8,12 +8,12 @@
 
 On Linux amd64 machine run:
 ```bash
-podman build -t quay.io/kubesmarts/logic-swf-builder-rhel8:1.35.0-kafka-persistence .
+podman build -t quay.io/kubesmarts/logic-swf-builder-rhel8:1.36.0-kafka-persistence .
 ```
 
 On Linux aarch64/macos run:
 ```bash
-docker buildx build --platform linux/amd64 -t quay.io/kubesmarts/logic-swf-builder-rhel8:1.35.0-kafka-persistence --load .
+docker buildx build --platform linux/amd64 -t quay.io/kubesmarts/logic-swf-builder-rhel8:1.36.0-kafka-persistence --load .
 ```
 
 ---

--- a/swf-image-builder/pom.xml
+++ b/swf-image-builder/pom.xml
@@ -12,7 +12,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.8.6.SP2-redhat-00002</quarkus.platform.version>
+        <quarkus.platform.version>3.15.4.redhat-00001</quarkus.platform.version>
+        <org.kie.version>9.103.0.redhat-00004</org.kie.version>
         <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     </properties>
@@ -31,19 +32,24 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.quarkiverse.openapi.generator</groupId>
+            <artifactId>quarkus-openapi-generator</artifactId>
+            <version>2.9.1-lts</version>
+        </dependency>
+        <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-persistence-jdbc</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
-            <version>3.8.6.redhat-00004</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-agroal</artifactId>
-            <version>3.8.6.redhat-00004</version>
+            <version>${quarkus.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -56,12 +62,12 @@
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kogito-addons-quarkus-knative-serving</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kogito-addons-quarkus-jobs-knative-eventing</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>com.aayushatharva.brotli4j</groupId>
@@ -71,7 +77,7 @@
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-monitoring-prometheus</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -80,42 +86,42 @@
         <dependency>
             <groupId>org.apache.kie.sonataflow</groupId>
             <artifactId>sonataflow-quarkus</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-events-process</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-process-management</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-kubernetes</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-knative-eventing</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-monitoring-sonataflow</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kie-addons-quarkus-source-files</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>${org.kie.version}</version>
         </dependency>
         <dependency>
             <groupId>org.kie</groupId>
             <artifactId>kogito-addons-quarkus-microprofile-config-service-catalog</artifactId>
-            <version>9.102.0.redhat-00005</version>
+            <version>9.103.0.redhat-00004</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
This PR cannot be merged as-is and needs to be updated once Maven repository is updated with required dependencies to enable a reproducible build of the builder image.

For now, it remains open as a reminder to be updated, and for anyone who would like to know how that image builder was built.