### PR TITLE
Provide workflow_id for running workflow from software template

### DIFF
--- a/05_software_template_hello_world/run-workflow-software-template/template.yaml
+++ b/05_software_template_hello_world/run-workflow-software-template/template.yaml
@@ -49,6 +49,7 @@ spec:
       name: Run workflow
       action: orchestrator:workflow:run
       input:
+        workflow_id: software-template-workflow
         parameters: ${{ parameters }}
 
   output:

--- a/05_software_template_hello_world/run-workflow-software-template/template.yaml
+++ b/05_software_template_hello_world/run-workflow-software-template/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: software-template-workflow # matches the workflow ID, will be used by orchestrator:workflow:run
+  name: software-template-workflow
   title: A workflow that invokes software templates from Backstage
   description: A sample workflow to invoke software templates and check their progress
 
@@ -49,7 +49,7 @@ spec:
       name: Run workflow
       action: orchestrator:workflow:run
       input:
-        workflow_id: software-template-workflow
+        workflow_id: software-template-workflow # matches the workflow ID from sonataflow
         parameters: ${{ parameters }}
 
   output:


### PR DESCRIPTION
Based on recent updates to the orchestrator scaffolder plugin, in order to invoke a workflow, the software template has to specify the workflow-id as an argument instead of relying on the software template name.