### PR TITLE
06 demo: add example for ui:order

### DIFF
--- a/06_form-widget-demo/http-workflow-dev-server/exampleWorkflows/schemas/dynamic-course-select__main-schema.json
+++ b/06_form-widget-demo/http-workflow-dev-server/exampleWorkflows/schemas/dynamic-course-select__main-schema.json
@@ -3,6 +3,13 @@
   "title": "Data Input Schema",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
+  "ui:order": [
+    "studentName",
+    "courseName",
+    "courseDetails",
+    "suggestedCourses",
+    "*"
+  ],
   "properties": {
     "studentName": {
       "type": "string",

--- a/06_form-widget-demo/http-workflow-dev-server/httpServer.dynamic.course.select.js
+++ b/06_form-widget-demo/http-workflow-dev-server/httpServer.dynamic.course.select.js
@@ -86,6 +86,8 @@ app.get('/coursedetailsschema', (req, res) => {
     return;
   }
 
+  const uiOrder = ['nickname', 'room'];
+
   const fields = {
     room: {
       type: 'string',
@@ -122,6 +124,7 @@ app.get('/coursedetailsschema', (req, res) => {
       title: 'Receive a certificate',
       'ui:widget': 'radio',
     };
+    uiOrder.push('requestCertificate');
   }
 
   const courseDetailsSchema = {
@@ -130,6 +133,7 @@ app.get('/coursedetailsschema', (req, res) => {
       type: 'object',
       title: `Course details for "${courseName}"`,
       properties: fields,
+      'ui:order': uiOrder,
     },
   };
 


### PR DESCRIPTION
This needs https://github.com/redhat-developer/rhdh-plugins/pull/1140 to work but it should not fail even if 1140 is missing (the `ui:order` option will be just ignored then).

The ui:order forces the order of input fields on the screen - https://rjsf-team.github.io/react-jsonschema-form/docs/usage/objects/#specifying-property-order