### PR TITLE
sonataflow CR now referencing workflow image

### DIFF
--- a/06_form-widget-demo/deploy/03-sonataflow_dynamic-course-select.yaml
+++ b/06_form-widget-demo/deploy/03-sonataflow_dynamic-course-select.yaml
@@ -37,7 +37,7 @@ spec:
         type: operation
   podTemplate:
     container:
-      image: quay.io/orchestrator/dynamic-course-demo-server:latest
+      image: quay.io/orchestrator/dynamic-course-demo-workflow:latest
       resources: {}
   resources:
     configMaps:


### PR DESCRIPTION
This fix will allow the workflow CR manifest to reference the workflow image, instead of the server image. 
Related to this bug https://issues.redhat.com/browse/FLPATH-2641